### PR TITLE
Re-introduces msg & tag methods; +new trim method

### DIFF
--- a/lib/oslg/oslog.rb
+++ b/lib/oslg/oslog.rb
@@ -167,7 +167,7 @@ module OSlg
   # @return [String] a trimmed message string (empty unless stringable)
   def trim(txt = "", length = 60)
     length = 60 unless length.respond_to?(:to_i)
-    length = length.to_i
+    length = length.to_i if length.respond_to?(:to_i)
     return "" unless txt.respond_to?(:to_s)
 
     txt = txt.to_s.strip

--- a/lib/oslg/oslog.rb
+++ b/lib/oslg/oslog.rb
@@ -207,7 +207,7 @@ module OSlg
     return @@status unless message.respond_to?(:to_s)
 
     lvl = lvl.to_i
-    message = trim(message)
+    message = message.to_s
     return @@status if lvl < DEBUG
     return @@status if lvl > FATAL
     return @@status if lvl < @@level

--- a/lib/oslg/version.rb
+++ b/lib/oslg/version.rb
@@ -29,5 +29,5 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module OSlg
-  VERSION = "0.2.8".freeze # OSlg version
+  VERSION = "0.2.9".freeze # OSlg version
 end

--- a/spec/oslg_tests_spec.rb
+++ b/spec/oslg_tests_spec.rb
@@ -86,12 +86,19 @@ RSpec.describe OSlg do
     expect(cls2.logs.empty?).to be(true)
 
     array = (1..60).to_a
+    l1 = 3 * 9 # "1, " + "2, " + "3, " ...+ "9, "
+    l2 = 4 * (59 - 9) # "10, " + "11, " + 12, ...+ "59, "
+    l3 = 2 # "60"
+    l4 = 2 # "[]"
+    expect(array.to_s.size).to eq(l1 + l2 + l3 + l4)
     expect(cls2.mismatch("x", "String", Array, array).nil?).to be(true)
     expect(cls2.logs.size).to eq(1)
     expect(cls2.logs.first.key?(:message))
-    str = "'x' String? expecting Array ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ..."
-    expect(cls2.logs.first[:message].length).to eq(60 + 4)
-    expect(cls2.logs.first[:message].include?(str)).to be(true)
+    str1 = "'x' String? expecting Array " # 28 chars
+    str2 = "([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,  ...)"
+    expect(str1.size + str2.size).to eq(28 + 60 + "(".length + " ...)".length)
+    expect(cls2.logs.first[:message].length).to eq(str1.size + str2.size)
+    expect(cls2.logs.first[:message]).to eq(str1 + str2)
 
     expect(cls2.clean!).to eq(cls2::DEBUG)
     expect(cls2.hashkey("x", {bar: 0}, "k", "foo")).to be(nil)

--- a/spec/oslg_tests_spec.rb
+++ b/spec/oslg_tests_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe OSlg do
   let(:mod2) { Module.new { extend OSlg } }
 
   it "can log within class instances" do
+    expect(cls1.trim(nil).length).to eq(0)
     expect(cls1.tag(cls1::DEBUG)).to eq("DEBUG")
     expect(cls1.msg(cls1::DEBUG)).to eq("Debugging ...")
 

--- a/spec/oslg_tests_spec.rb
+++ b/spec/oslg_tests_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe OSlg do
   let(:mod2) { Module.new { extend OSlg } }
 
   it "can log within class instances" do
+    expect(cls1.tag(cls1::DEBUG)).to eq("DEBUG")
+    expect(cls1.msg(cls1::DEBUG)).to eq("Debugging ...")
+
     expect(cls1.clean!).to eq(cls1::INFO)
     expect(cls1.log(cls1::INFO, "Logging within cls1")).to eq(cls1::INFO)
 
@@ -86,7 +89,8 @@ RSpec.describe OSlg do
     expect(cls2.mismatch("x", "String", Array, array).nil?).to be(true)
     expect(cls2.logs.size).to eq(1)
     expect(cls2.logs.first.key?(:message))
-    str = "'x' String? expecting Array ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,"
+    str = "'x' String? expecting Array ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ..."
+    expect(cls2.logs.first[:message].length).to eq(60 + 4)
     expect(cls2.logs.first[:message].include?(str)).to be(true)
 
     expect(cls2.clean!).to eq(cls2::DEBUG)


### PR DESCRIPTION
Re-introduces **msg** & **tag** methods
- ... set aside in v0.2.8 (not used internally)
- nonetheless useful for 3rd-party gems

Adds new **trim** method
- one-liner method that a converts _stringable_ object, and trims if necessary
- can be useful for 3rd-party gems that include/extend OSlg 

Improves on Yard documentation